### PR TITLE
improv(core): Allow skipping of backreferences

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs",
   "private": true,
-  "version": "0.1.13-alpha.4",
+  "version": "0.1.13-alpha.5",
   "scripts": {
     "build": "rm -fr dist cache && parcel build index.pug --public-url /textcomplete",
     "format:eslint": "eslint --fix '**/*.ts' '**/*.tsx'",
@@ -11,10 +11,10 @@
     "start": "parcel index.pug"
   },
   "dependencies": {
-    "@textcomplete/codemirror": "^0.1.13-alpha.4",
-    "@textcomplete/contenteditable": "^0.1.13-alpha.4",
-    "@textcomplete/core": "^0.1.13-alpha.4",
-    "@textcomplete/textarea": "^0.1.13-alpha.4",
+    "@textcomplete/codemirror": "^0.1.13-alpha.5",
+    "@textcomplete/contenteditable": "^0.1.13-alpha.5",
+    "@textcomplete/core": "^0.1.13-alpha.5",
+    "@textcomplete/textarea": "^0.1.13-alpha.5",
     "codemirror": "^5.54.0",
     "prism-react-renderer": "^1.1.1",
     "react": "^17.0.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs",
   "private": true,
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "scripts": {
     "build": "rm -fr dist cache && parcel build index.pug --public-url /textcomplete",
     "format:eslint": "eslint --fix '**/*.ts' '**/*.tsx'",
@@ -11,10 +11,10 @@
     "start": "parcel index.pug"
   },
   "dependencies": {
-    "@textcomplete/codemirror": "^0.1.13-alpha.5",
-    "@textcomplete/contenteditable": "^0.1.13-alpha.5",
-    "@textcomplete/core": "^0.1.13-alpha.5",
-    "@textcomplete/textarea": "^0.1.13-alpha.5",
+    "@textcomplete/codemirror": "^0.1.13-alpha.6",
+    "@textcomplete/contenteditable": "^0.1.13-alpha.6",
+    "@textcomplete/core": "^0.1.13-alpha.6",
+    "@textcomplete/textarea": "^0.1.13-alpha.6",
     "codemirror": "^5.54.0",
     "prism-react-renderer": "^1.1.1",
     "react": "^17.0.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "docs",
   "private": true,
-  "version": "0.1.12",
+  "version": "0.1.13-alpha.4",
   "scripts": {
     "build": "rm -fr dist cache && parcel build index.pug --public-url /textcomplete",
     "format:eslint": "eslint --fix '**/*.ts' '**/*.tsx'",
@@ -11,10 +11,10 @@
     "start": "parcel index.pug"
   },
   "dependencies": {
-    "@textcomplete/codemirror": "^0.1.11",
-    "@textcomplete/contenteditable": "^0.1.12",
-    "@textcomplete/core": "^0.1.11",
-    "@textcomplete/textarea": "^0.1.11",
+    "@textcomplete/codemirror": "^0.1.13-alpha.4",
+    "@textcomplete/contenteditable": "^0.1.13-alpha.4",
+    "@textcomplete/core": "^0.1.13-alpha.4",
+    "@textcomplete/textarea": "^0.1.13-alpha.4",
     "codemirror": "^5.54.0",
     "prism-react-renderer": "^1.1.1",
     "react": "^17.0.2",

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.13-alpha.4",
+  "version": "0.1.13-alpha.5",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.12",
+  "version": "0.1.13-alpha.4",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {

--- a/packages/textcomplete-codemirror/package.json
+++ b/packages/textcomplete-codemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/codemirror",
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "description": "Textcomplete editor for CodeMirror",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,7 +16,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.13-alpha.5",
+    "@textcomplete/core": "^0.1.13-alpha.6",
     "@types/codemirror": "^5.60.2",
     "codemirror": "^5.54"
   },

--- a/packages/textcomplete-codemirror/package.json
+++ b/packages/textcomplete-codemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/codemirror",
-  "version": "0.1.12",
+  "version": "0.1.13-alpha.4",
   "description": "Textcomplete editor for CodeMirror",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,7 +16,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.11",
+    "@textcomplete/core": "^0.1.13-alpha.4",
     "@types/codemirror": "^5.60.2",
     "codemirror": "^5.54"
   },

--- a/packages/textcomplete-codemirror/package.json
+++ b/packages/textcomplete-codemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/codemirror",
-  "version": "0.1.13-alpha.4",
+  "version": "0.1.13-alpha.5",
   "description": "Textcomplete editor for CodeMirror",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,7 +16,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.13-alpha.4",
+    "@textcomplete/core": "^0.1.13-alpha.5",
     "@types/codemirror": "^5.60.2",
     "codemirror": "^5.54"
   },

--- a/packages/textcomplete-contenteditable/package.json
+++ b/packages/textcomplete-contenteditable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/contenteditable",
-  "version": "0.1.13-alpha.4",
+  "version": "0.1.13-alpha.5",
   "description": "Textcomplete editor for contenteditable",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,10 +16,10 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "dependencies": {
-    "@textcomplete/utils": "^0.1.13-alpha.4"
+    "@textcomplete/utils": "^0.1.13-alpha.5"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.13-alpha.4"
+    "@textcomplete/core": "^0.1.13-alpha.5"
   },
   "peerDependencies": {
     "@textcomplete/core": "^0.1.9"

--- a/packages/textcomplete-contenteditable/package.json
+++ b/packages/textcomplete-contenteditable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/contenteditable",
-  "version": "0.1.12",
+  "version": "0.1.13-alpha.4",
   "description": "Textcomplete editor for contenteditable",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,10 +16,10 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "dependencies": {
-    "@textcomplete/utils": "^0.1.11"
+    "@textcomplete/utils": "^0.1.13-alpha.4"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.11"
+    "@textcomplete/core": "^0.1.13-alpha.4"
   },
   "peerDependencies": {
     "@textcomplete/core": "^0.1.9"

--- a/packages/textcomplete-contenteditable/package.json
+++ b/packages/textcomplete-contenteditable/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/contenteditable",
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "description": "Textcomplete editor for contenteditable",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,10 +16,10 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "dependencies": {
-    "@textcomplete/utils": "^0.1.13-alpha.5"
+    "@textcomplete/utils": "^0.1.13-alpha.6"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.13-alpha.5"
+    "@textcomplete/core": "^0.1.13-alpha.6"
   },
   "peerDependencies": {
     "@textcomplete/core": "^0.1.9"

--- a/packages/textcomplete-core/package.json
+++ b/packages/textcomplete-core/package.json
@@ -17,9 +17,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "eventemitter3": "^4.0.4"
-  },
-  "devDependemcoes": {
+    "eventemitter3": "^4.0.4",
     "typescript": "^4.4.3"
   },
   "publishConfig": {

--- a/packages/textcomplete-core/package.json
+++ b/packages/textcomplete-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/core",
-  "version": "0.1.12",
+  "version": "0.1.13-alpha.4",
   "description": "Textcomplete core.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/textcomplete-core/package.json
+++ b/packages/textcomplete-core/package.json
@@ -19,6 +19,9 @@
   "dependencies": {
     "eventemitter3": "^4.0.4"
   },
+  "devDependemcoes": {
+    "typescript": "^4.4.3"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/textcomplete-core/package.json
+++ b/packages/textcomplete-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/core",
-  "version": "0.1.13-alpha.4",
+  "version": "0.1.13-alpha.5",
   "description": "Textcomplete core.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/textcomplete-core/package.json
+++ b/packages/textcomplete-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/core",
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "description": "Textcomplete core.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/textcomplete-core/src/Dropdown.ts
+++ b/packages/textcomplete-core/src/Dropdown.ts
@@ -316,7 +316,7 @@ class DropdownItem {
     span.innerHTML = this.searchResult.render()
     li.appendChild(span)
 
-    li.addEventListener("click", this.onClick)
+    li.addEventListener("mousedown", this.onClick)
 
     this.el = li
   }
@@ -324,7 +324,7 @@ class DropdownItem {
   destroy(): this {
     const li = this.el
     li.parentNode?.removeChild(li)
-    li.removeEventListener("click", this.onClick, false)
+    li.removeEventListener("mousedown", this.onClick, false)
     return this
   }
 

--- a/packages/textcomplete-core/src/SearchResult.ts
+++ b/packages/textcomplete-core/src/SearchResult.ts
@@ -10,7 +10,7 @@ export class SearchResult<T = unknown> {
     private readonly strategy: Strategy<T>
   ) {}
 
-  getReplacementData(beforeCursor: string, skipBackReferences: boolean): {
+  getReplacementData(beforeCursor: string): {
     start: number
     end: number
     beforeCursor: string
@@ -29,7 +29,7 @@ export class SearchResult<T = unknown> {
     let replacement = result
       .replace(MAIN, match[0]);
     
-    if(!skipBackReferences) {
+    if(!this.strategy.skipBackReferences()) {
       replacement = replacement.replace(PLACE, (_, p) => match[parseInt(p)])
     }
 
@@ -41,8 +41,8 @@ export class SearchResult<T = unknown> {
     }
   }
 
-  replace(beforeCursor: string, afterCursor: string, skipBackReferences: boolean = false): [string, string] | void {
-    const replacement = this.getReplacementData(beforeCursor, skipBackReferences)
+  replace(beforeCursor: string, afterCursor: string): [string, string] | void {
+    const replacement = this.getReplacementData(beforeCursor)
 
     if (replacement === null) return
 

--- a/packages/textcomplete-core/src/SearchResult.ts
+++ b/packages/textcomplete-core/src/SearchResult.ts
@@ -10,7 +10,7 @@ export class SearchResult<T = unknown> {
     private readonly strategy: Strategy<T>
   ) {}
 
-  getReplacementData(beforeCursor: string): {
+  getReplacementData(beforeCursor: string, skipBackReferences: boolean): {
     start: number
     end: number
     beforeCursor: string
@@ -26,9 +26,12 @@ export class SearchResult<T = unknown> {
     }
     const match = this.strategy.match(beforeCursor)
     if (match == null || match.index == null) return null
-    const replacement = result
-      .replace(MAIN, match[0])
-      .replace(PLACE, (_, p) => match[parseInt(p)])
+    let replacement = result
+      .replace(MAIN, match[0]);
+    
+    if(!skipBackReferences) {
+      replacement = replacement.replace(PLACE, (_, p) => match[parseInt(p)])
+    }
 
     return {
       start: match.index,
@@ -38,8 +41,8 @@ export class SearchResult<T = unknown> {
     }
   }
 
-  replace(beforeCursor: string, afterCursor: string): [string, string] | void {
-    const replacement = this.getReplacementData(beforeCursor)
+  replace(beforeCursor: string, afterCursor: string, skipBackReferences: boolean = false): [string, string] | void {
+    const replacement = this.getReplacementData(beforeCursor, skipBackReferences)
 
     if (replacement === null) return
 

--- a/packages/textcomplete-core/src/Strategy.ts
+++ b/packages/textcomplete-core/src/Strategy.ts
@@ -67,8 +67,8 @@ export class Strategy<T> {
     return this.props.id || null
   }
 
-  skipBackReferences(): boolean | null {
-    return this.props.skipBackReferences || null
+  skipBackReferences(): boolean  {
+    return this.props.skipBackReferences || false
   }
 
   match(text: string): RegExpMatchArray | null {

--- a/packages/textcomplete-core/src/Strategy.ts
+++ b/packages/textcomplete-core/src/Strategy.ts
@@ -21,7 +21,7 @@ export interface StrategyProps<T = any> {
 }
 
 export const DEFAULT_INDEX = 1
-
+const DEFAULT_SKIP_BACK_REFERENCES = false
 export class Strategy<T> {
   private cache: Record<string, T[]> = {}
 
@@ -68,7 +68,7 @@ export class Strategy<T> {
   }
 
   skipBackReferences(): boolean  {
-    return this.props.skipBackReferences || false
+    return this.props.skipBackReferences || DEFAULT_SKIP_BACK_REFERENCES
   }
 
   match(text: string): RegExpMatchArray | null {

--- a/packages/textcomplete-core/src/Strategy.ts
+++ b/packages/textcomplete-core/src/Strategy.ts
@@ -12,6 +12,7 @@ export interface StrategyProps<T = any> {
     match: RegExpMatchArray
   ) => void
   replace: (data: T) => ReplaceResult
+  skipBackReferences?: boolean
   cache?: boolean
   context?: (text: string) => string | boolean
   template?: (data: T, term: string) => string
@@ -64,6 +65,10 @@ export class Strategy<T> {
 
   getId(): string | null {
     return this.props.id || null
+  }
+
+  skipBackReferences(): boolean | null {
+    return this.props.skipBackReferences || null
   }
 
   match(text: string): RegExpMatchArray | null {

--- a/packages/textcomplete-core/tsconfig.json
+++ b/packages/textcomplete-core/tsconfig.json
@@ -1,7 +1,18 @@
 {
-  "extends": "../../tsconfig-base.json",
   "compilerOptions": {
     "outDir": "dist",
+    "jsx": "react",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "target": "ES6",
+    "module": "commonjs",
+    "lib": ["ES2019", "DOM"],
+    "sourceMap": true,
+    "declaration": true,
+    "strict": true,
+    "noImplicitThis": true,
+    "noImplicitAny": true,
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*"

--- a/packages/textcomplete-textarea/package.json
+++ b/packages/textcomplete-textarea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/textarea",
-  "version": "0.1.13-alpha.4",
+  "version": "0.1.13-alpha.5",
   "description": "Textcomplete editor for HTMLTextAreaElement",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,12 +16,12 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "dependencies": {
-    "@textcomplete/utils": "^0.1.13-alpha.4",
+    "@textcomplete/utils": "^0.1.13-alpha.5",
     "textarea-caret": "^3.1.0",
     "undate": "^0.3.0"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.13-alpha.4",
+    "@textcomplete/core": "^0.1.13-alpha.5",
     "@types/textarea-caret": "^3.0.0"
   },
   "peerDependencies": {

--- a/packages/textcomplete-textarea/package.json
+++ b/packages/textcomplete-textarea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/textarea",
-  "version": "0.1.12",
+  "version": "0.1.13-alpha.4",
   "description": "Textcomplete editor for HTMLTextAreaElement",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,12 +16,12 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "dependencies": {
-    "@textcomplete/utils": "^0.1.11",
+    "@textcomplete/utils": "^0.1.13-alpha.4",
     "textarea-caret": "^3.1.0",
     "undate": "^0.3.0"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.11",
+    "@textcomplete/core": "^0.1.13-alpha.4",
     "@types/textarea-caret": "^3.0.0"
   },
   "peerDependencies": {

--- a/packages/textcomplete-textarea/package.json
+++ b/packages/textcomplete-textarea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/textarea",
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "description": "Textcomplete editor for HTMLTextAreaElement",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,12 +16,12 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "dependencies": {
-    "@textcomplete/utils": "^0.1.13-alpha.5",
+    "@textcomplete/utils": "^0.1.13-alpha.6",
     "textarea-caret": "^3.1.0",
     "undate": "^0.3.0"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.13-alpha.5",
+    "@textcomplete/core": "^0.1.13-alpha.6",
     "@types/textarea-caret": "^3.0.0"
   },
   "peerDependencies": {

--- a/packages/textcomplete-utils/package.json
+++ b/packages/textcomplete-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/utils",
-  "version": "0.1.13-alpha.5",
+  "version": "0.1.13-alpha.6",
   "description": "Utility functions for Textcomplete editors",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,7 +16,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.13-alpha.5",
+    "@textcomplete/core": "^0.1.13-alpha.6",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
     "eslint": "^7.21.0",

--- a/packages/textcomplete-utils/package.json
+++ b/packages/textcomplete-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/utils",
-  "version": "0.1.13-alpha.4",
+  "version": "0.1.13-alpha.5",
   "description": "Utility functions for Textcomplete editors",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,7 +16,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.13-alpha.4",
+    "@textcomplete/core": "^0.1.13-alpha.5",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
     "eslint": "^7.21.0",

--- a/packages/textcomplete-utils/package.json
+++ b/packages/textcomplete-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@textcomplete/utils",
-  "version": "0.1.12",
+  "version": "0.1.13-alpha.4",
   "description": "Utility functions for Textcomplete editors",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -16,7 +16,7 @@
     "lint": "eslint 'src/**/*.ts'"
   },
   "devDependencies": {
-    "@textcomplete/core": "^0.1.11",
+    "@textcomplete/core": "^0.1.13-alpha.4",
     "@typescript-eslint/eslint-plugin": "^4.17.0",
     "@typescript-eslint/parser": "^4.17.0",
     "eslint": "^7.21.0",


### PR DESCRIPTION
CAP-8795

Will include Loom in our private repo on the accompanying PR.

This PR allows us to ignore `$` characters in autocomplete regex's. It also addresses a regression when upgrading to 0.1.12.

![image](https://user-images.githubusercontent.com/1541492/178604216-1ce08a12-0a8a-481c-88d4-1051a4f667a2.png)


